### PR TITLE
feat: added fallback for Safari directory selection (#feat/safari-fallback)

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,14 @@
         <div class="drop-zone bg-white border-2 border-dashed border-gray-300 rounded-lg p-8 text-center transition-colors duration-200 hover:border-gray-400">
             <div class="text-gray-600 mb-4">Drop folder or file here</div>
             <!-- The button will be injected here by JS -->
+            <!-- For Safari -->
+            <input 
+                id="fallbackInput" 
+                type="file" 
+                webkitdirectory 
+                multiple 
+                style="display: none;"
+            />
         </div>
         
         <div id="drop-status" class="text-red-500 font-medium"></div>


### PR DESCRIPTION
- Implemented fallback using input[type="file" webkitdirectory] for browsers that do not support File System Access API (e.g., Safari).
- Added a hidden input with id="fallbackInput" in **index.html** for folder selection.
- Updated **script.js**:
  - Added feature detection for window.showDirectoryPicker.
  - Integrated fallback via fallbackInput.click() when modern API is unavailable.
  - Created processFallbackFiles function to handle files from FileList.
  - Updated Select Directory button logic to support both modern API and fallback.